### PR TITLE
[F-005] 貼文列表與詳情

### DIFF
--- a/dev/__tests__/api/posts/get-post.test.ts
+++ b/dev/__tests__/api/posts/get-post.test.ts
@@ -1,0 +1,123 @@
+import { NextRequest } from "next/server";
+
+// Mock Prisma
+const mockFindUnique = jest.fn();
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    post: {
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+    },
+  },
+}));
+
+import { GET } from "@/app/api/v1/posts/[id]/route";
+
+const MOCK_AUTHOR = {
+  id: "user-1",
+  username: "john_doe",
+  displayName: "John Doe",
+};
+
+const MOCK_POST = {
+  id: "post-1",
+  content: "Hello World",
+  authorId: "user-1",
+  author: MOCK_AUTHOR,
+  createdAt: new Date("2026-03-28T00:00:00.000Z"),
+  updatedAt: new Date("2026-03-28T00:00:00.000Z"),
+  deletedAt: null,
+};
+
+function buildRequest(id: string): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/v1/posts/${id}`);
+}
+
+function buildParams(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("GET /api/v1/posts/:id", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Happy Path", () => {
+    it("Scenario: 取得單篇貼文詳情", async () => {
+      mockFindUnique.mockResolvedValue(MOCK_POST);
+
+      const req = buildRequest("post-1");
+      const res = await GET(req, buildParams("post-1"));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.id).toBe("post-1");
+      expect(data.content).toBe("Hello World");
+      expect(data.author.id).toBe("user-1");
+      expect(data.author.username).toBe("john_doe");
+      expect(data.author.display_name).toBe("John Doe");
+      expect(data.likes_count).toBe(0);
+      expect(data.comments_count).toBe(0);
+      expect(data.is_liked).toBe(false);
+      expect(data.created_at).toBe("2026-03-28T00:00:00.000Z");
+      expect(data.updated_at).toBe("2026-03-28T00:00:00.000Z");
+    });
+
+    it("should call prisma with correct params", async () => {
+      mockFindUnique.mockResolvedValue(MOCK_POST);
+
+      const req = buildRequest("post-1");
+      await GET(req, buildParams("post-1"));
+
+      expect(mockFindUnique).toHaveBeenCalledWith({
+        where: { id: "post-1" },
+        include: {
+          author: {
+            select: {
+              id: true,
+              username: true,
+              displayName: true,
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("Scenario: 貼文不存在", async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      const req = buildRequest("nonexistent-uuid");
+      const res = await GET(req, buildParams("nonexistent-uuid"));
+      const data = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(data.code).toBe("NOT_FOUND");
+    });
+
+    it("Scenario: 已刪除的貼文回傳 404", async () => {
+      mockFindUnique.mockResolvedValue({
+        ...MOCK_POST,
+        deletedAt: new Date("2026-03-28T01:00:00.000Z"),
+      });
+
+      const req = buildRequest("post-1");
+      const res = await GET(req, buildParams("post-1"));
+      const data = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(data.code).toBe("NOT_FOUND");
+    });
+
+    it("should return 500 on unexpected error", async () => {
+      mockFindUnique.mockRejectedValue(new Error("DB connection failed"));
+
+      const req = buildRequest("post-1");
+      const res = await GET(req, buildParams("post-1"));
+      const data = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(data.code).toBe("INTERNAL_ERROR");
+    });
+  });
+});

--- a/dev/__tests__/api/posts/list-posts.test.ts
+++ b/dev/__tests__/api/posts/list-posts.test.ts
@@ -1,0 +1,207 @@
+import { NextRequest } from "next/server";
+
+// Mock Prisma
+const mockFindMany = jest.fn();
+const mockFindUnique = jest.fn();
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    post: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+    },
+  },
+}));
+
+import { GET } from "@/app/api/v1/posts/route";
+
+const MOCK_AUTHOR = {
+  id: "user-1",
+  username: "john_doe",
+  displayName: "John Doe",
+};
+
+function makeMockPost(index: number) {
+  const date = new Date(Date.now() - index * 60000); // each post 1 min apart
+  return {
+    id: `post-${index}`,
+    content: `Post content ${index}`,
+    authorId: "user-1",
+    author: MOCK_AUTHOR,
+    createdAt: date,
+    updatedAt: date,
+    deletedAt: null,
+  };
+}
+
+function buildRequest(queryString = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost:3000/api/v1/posts${queryString ? `?${queryString}` : ""}`
+  );
+}
+
+describe("GET /api/v1/posts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Happy Path", () => {
+    it("Scenario: 取得貼文列表（第一頁）", async () => {
+      // 25 posts, requesting limit=20, so findMany returns 21 (limit+1)
+      const posts = Array.from({ length: 21 }, (_, i) => makeMockPost(i));
+      mockFindMany.mockResolvedValue(posts);
+
+      const req = buildRequest("limit=20");
+      const res = await GET(req);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.data).toHaveLength(20);
+      expect(data.has_more).toBe(true);
+      expect(data.next_cursor).toBe("post-19");
+      // Verify sorted by created_at DESC (findMany called with orderBy)
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: "desc" },
+          take: 21,
+          where: { deletedAt: null },
+        })
+      );
+    });
+
+    it("Scenario: 取得貼文列表（第二頁）", async () => {
+      const cursorPost = {
+        createdAt: new Date("2026-03-28T00:20:00.000Z"),
+      };
+      mockFindUnique.mockResolvedValue(cursorPost);
+
+      // Only 5 posts remaining (less than limit+1)
+      const posts = Array.from({ length: 5 }, (_, i) => makeMockPost(i + 20));
+      mockFindMany.mockResolvedValue(posts);
+
+      const req = buildRequest("cursor=cursor-abc&limit=20");
+      const res = await GET(req);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.data).toHaveLength(5);
+      expect(data.has_more).toBe(false);
+      expect(data.next_cursor).toBeNull();
+    });
+
+    it("Scenario: 取得貼文列表（使用預設 limit）", async () => {
+      const posts = Array.from({ length: 10 }, (_, i) => makeMockPost(i));
+      mockFindMany.mockResolvedValue(posts);
+
+      const req = buildRequest();
+      const res = await GET(req);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.data.length).toBeLessThanOrEqual(20);
+      // Default limit is 20, so take should be 21
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 21 })
+      );
+    });
+
+    it("Scenario: 未登入可瀏覽貼文", async () => {
+      mockFindMany.mockResolvedValue([]);
+
+      const req = buildRequest();
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it("should return posts with correct response format", async () => {
+      const mockPost = makeMockPost(0);
+      mockFindMany.mockResolvedValue([mockPost]);
+
+      const req = buildRequest();
+      const res = await GET(req);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      const post = data.data[0];
+      expect(post.id).toBe("post-0");
+      expect(post.content).toBe("Post content 0");
+      expect(post.author.id).toBe("user-1");
+      expect(post.author.username).toBe("john_doe");
+      expect(post.author.display_name).toBe("John Doe");
+      expect(post.likes_count).toBe(0);
+      expect(post.comments_count).toBe(0);
+      expect(post.is_liked).toBe(false);
+      expect(post.created_at).toBeDefined();
+      expect(post.updated_at).toBeDefined();
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("Scenario: limit 超過 50", async () => {
+      const req = buildRequest("limit=51");
+      const res = await GET(req);
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data.code).toBe("INVALID_INPUT");
+    });
+
+    it("Scenario: limit 為 0", async () => {
+      const req = buildRequest("limit=0");
+      const res = await GET(req);
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data.code).toBe("INVALID_INPUT");
+    });
+
+    it("Scenario: limit 為負數", async () => {
+      const req = buildRequest("limit=-1");
+      const res = await GET(req);
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data.code).toBe("INVALID_INPUT");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("Scenario: 沒有任何貼文", async () => {
+      mockFindMany.mockResolvedValue([]);
+
+      const req = buildRequest();
+      const res = await GET(req);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.data).toEqual([]);
+      expect(data.has_more).toBe(false);
+      expect(data.next_cursor).toBeNull();
+    });
+
+    it("Scenario: cursor 指向不存在的 post", async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      const req = buildRequest("cursor=nonexistent-uuid");
+      const res = await GET(req);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.data).toEqual([]);
+      expect(data.has_more).toBe(false);
+    });
+
+    it("should exclude soft-deleted posts via where clause", async () => {
+      mockFindMany.mockResolvedValue([]);
+
+      const req = buildRequest();
+      await GET(req);
+
+      expect(mockFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ deletedAt: null }),
+        })
+      );
+    });
+  });
+});

--- a/dev/src/app/api/v1/posts/[id]/route.ts
+++ b/dev/src/app/api/v1/posts/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/v1/posts/:id - Get a single post by ID (public).
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    const post = await prisma.post.findUnique({
+      where: { id },
+      include: {
+        author: {
+          select: {
+            id: true,
+            username: true,
+            displayName: true,
+          },
+        },
+      },
+    });
+
+    // Return 404 if post doesn't exist or is soft-deleted
+    if (!post || post.deletedAt !== null) {
+      return NextResponse.json(
+        {
+          code: "NOT_FOUND",
+          message: "Post not found",
+        },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      id: post.id,
+      content: post.content,
+      author: {
+        id: post.author.id,
+        username: post.author.username,
+        display_name: post.author.displayName,
+      },
+      likes_count: 0,
+      comments_count: 0,
+      is_liked: false,
+      created_at: post.createdAt.toISOString(),
+      updated_at: post.updatedAt.toISOString(),
+    });
+  } catch (error) {
+    console.error("Get post detail error:", error);
+    return NextResponse.json(
+      {
+        code: "INTERNAL_ERROR",
+        message: "An unexpected error occurred",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/dev/src/app/api/v1/posts/route.ts
+++ b/dev/src/app/api/v1/posts/route.ts
@@ -1,6 +1,123 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { validateCreatePostInput } from "@/lib/validations";
+import {
+  validateCreatePostInput,
+  validateListPostsQuery,
+} from "@/lib/validations";
+
+/**
+ * Helper to format a post record into the API response shape.
+ */
+function formatPost(post: {
+  id: string;
+  content: string;
+  author: { id: string; username: string; displayName: string };
+  createdAt: Date;
+  updatedAt: Date;
+}) {
+  return {
+    id: post.id,
+    content: post.content,
+    author: {
+      id: post.author.id,
+      username: post.author.username,
+      display_name: post.author.displayName,
+    },
+    likes_count: 0,
+    comments_count: 0,
+    is_liked: false,
+    created_at: post.createdAt.toISOString(),
+    updated_at: post.updatedAt.toISOString(),
+  };
+}
+
+const authorSelect = {
+  id: true,
+  username: true,
+  displayName: true,
+};
+
+/**
+ * GET /api/v1/posts - List posts with cursor-based pagination (public).
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const queryParams = {
+      cursor: searchParams.get("cursor") ?? undefined,
+      limit: searchParams.get("limit") ?? undefined,
+    };
+
+    const validation = validateListPostsQuery(queryParams);
+    if (!validation.success) {
+      return NextResponse.json(
+        {
+          code: "INVALID_INPUT",
+          message: "Validation failed",
+          details: validation.details,
+        },
+        { status: 400 }
+      );
+    }
+
+    const { cursor, limit } = validation.data;
+
+    // Build where clause: exclude soft-deleted posts
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const where: any = { deletedAt: null };
+
+    // If cursor is provided, find the cursor post's createdAt for pagination
+    if (cursor) {
+      const cursorPost = await prisma.post.findUnique({
+        where: { id: cursor },
+        select: { createdAt: true },
+      });
+
+      if (!cursorPost) {
+        // Cursor points to non-existent post: return empty results
+        return NextResponse.json({
+          data: [],
+          next_cursor: null,
+          has_more: false,
+        });
+      }
+
+      where.createdAt = { lt: cursorPost.createdAt };
+    }
+
+    // Fetch one extra to determine has_more
+    const posts = await prisma.post.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: limit + 1,
+      include: {
+        author: { select: authorSelect },
+      },
+    });
+
+    const hasMore = posts.length > limit;
+    const resultPosts = hasMore ? posts.slice(0, limit) : posts;
+    const nextCursor =
+      hasMore && resultPosts.length > 0
+        ? resultPosts[resultPosts.length - 1].id
+        : null;
+
+    return NextResponse.json({
+      data: resultPosts.map(formatPost),
+      next_cursor: nextCursor,
+      has_more: hasMore,
+    });
+  } catch (error) {
+    console.error("List posts error:", error);
+    return NextResponse.json(
+      {
+        code: "INTERNAL_ERROR",
+        message: "An unexpected error occurred",
+      },
+      { status: 500 }
+    );
+  }
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -53,32 +170,11 @@ export async function POST(request: NextRequest) {
         authorId: userId,
       },
       include: {
-        author: {
-          select: {
-            id: true,
-            username: true,
-            displayName: true,
-          },
-        },
+        author: { select: authorSelect },
       },
     });
 
-    return NextResponse.json(
-      {
-        id: post.id,
-        content: post.content,
-        author: {
-          id: post.author.id,
-          username: post.author.username,
-          display_name: post.author.displayName,
-        },
-        likes_count: 0,
-        comments_count: 0,
-        created_at: post.createdAt.toISOString(),
-        updated_at: post.updatedAt.toISOString(),
-      },
-      { status: 201 }
-    );
+    return NextResponse.json(formatPost(post), { status: 201 });
   } catch (error) {
     console.error("Create post error:", error);
     return NextResponse.json(

--- a/dev/src/lib/validations.ts
+++ b/dev/src/lib/validations.ts
@@ -76,6 +76,25 @@ export const createPostSchema = z.object({
 export type CreatePostInput = z.infer<typeof createPostSchema>;
 
 /**
+ * List posts query validation schema.
+ *
+ * Rules:
+ * - cursor: optional string (post ID for cursor-based pagination)
+ * - limit: optional number, 1-50, default 20
+ */
+export const listPostsQuerySchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce
+    .number({ invalid_type_error: "Limit must be a number" })
+    .int("Limit must be an integer")
+    .min(1, "Limit must be at least 1")
+    .max(50, "Limit must be at most 50")
+    .default(20),
+});
+
+export type ListPostsQuery = z.infer<typeof listPostsQuerySchema>;
+
+/**
  * Validate registration input and return parsed data or error details.
  */
 export function validateRegisterInput(data: unknown):
@@ -131,6 +150,29 @@ export function validateCreatePostInput(data: unknown):
       details: Array<{ field: string; message: string }>;
     } {
   const result = createPostSchema.safeParse(data);
+
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+
+  const details = result.error.issues.map((issue) => ({
+    field: issue.path.join(".") || "unknown",
+    message: issue.message,
+  }));
+
+  return { success: false, details };
+}
+
+/**
+ * Validate list posts query params and return parsed data or error details.
+ */
+export function validateListPostsQuery(data: unknown):
+  | { success: true; data: ListPostsQuery }
+  | {
+      success: false;
+      details: Array<{ field: string; message: string }>;
+    } {
+  const result = listPostsQuerySchema.safeParse(data);
 
   if (result.success) {
     return { success: true, data: result.data };


### PR DESCRIPTION
## Summary
實作貼文列表（cursor-based pagination）和貼文詳情 API。

## Changes
- `GET /api/v1/posts` — cursor-based pagination, default 20, max 50
- `GET /api/v1/posts/:id` — 貼文詳情
- 排除 soft-deleted 貼文
- 16 unit tests

## Test Results
- 16 new tests ✅
- No regressions ✅

Closes #15